### PR TITLE
Restructure container to be based on Alpine over CentOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM centos:7
+FROM alpine:3.11
 
-RUN yum update -y
-RUN yum -y install dnsmasq
+RUN apk add --update --no-cache dnsmasq
 
 COPY dnsmasq.conf /etc/
 COPY resolv.dnsmasq.conf /etc/


### PR DESCRIPTION
- Smaller container image
- Less overhead
- More up to date (maybe?)

CentOS: 162.62mb (according to Docker Hub)
Alpine: 5.59mb